### PR TITLE
Fix TikTok icon import

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,6 @@
 // src/components/Footer.jsx
 import React from 'react';
+import { Instagram, Music2 } from 'lucide-react';
 import '../styles/main.css';
 
 const Footer = () => {
@@ -19,8 +20,22 @@ const Footer = () => {
         </div>
 
         <div className="footer-social">
-          <a href="https://instagram.com/motocamp" target="_blank" rel="noopener noreferrer">Instagram</a>
-          <a href="https://tiktok.com/@motocamp" target="_blank" rel="noopener noreferrer">TikTok</a>
+          <a
+            href="https://instagram.com/motocamp"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <Instagram size={28} />
+          </a>
+          <a
+            href="https://tiktok.com/@motocamp"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="TikTok"
+          >
+            <Music2 size={28} />
+          </a>
         </div>
       </div>
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -423,6 +423,13 @@ html, body, #root {
   color: #eee;
   text-decoration: none;
   transition: color 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+}
+
+.footer-social svg {
+  width: 28px;
+  height: 28px;
 }
 
 .footer-links a:hover,


### PR DESCRIPTION
## Summary
- correct lucide-react import in `Footer` by switching to `Music2` icon

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845018d14e48329922681dba2380ad3